### PR TITLE
fix(useDynamicSizeGrid): correct view virtualColumns if comming items empty

### DIFF
--- a/virtualization-from-scratch/src/examples/Grid.tsx
+++ b/virtualization-from-scratch/src/examples/Grid.tsx
@@ -334,7 +334,7 @@ function useDynamicSizeGrid(props: UseDynamicSizeGridProps) {
     }
 
     columnStartIndex = Math.max(0, columnStartIndex - overscanY);
-    columnEndIndex = Math.min(rowsCount - 1, columnEndIndex + overscanY);
+    columnEndIndex = Math.min(columnsCount - 1, columnEndIndex + overscanY);
 
     const virtualColumns = allColumns.slice(
       columnStartIndex,


### PR DESCRIPTION
 если с сервера придет 1 item, то соответственно отобразиться лишь всего одна колонка в virtualColumns у, например, тайтлов